### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,10 +17,10 @@ distlib==0.3.9
 filelock==3.16.1
 Flask==2.2.5
 Flask-SQLAlchemy==3.1.1
-h11==0.12.0
-httpcore==0.13.3
+h11==0.16.0
+httpcore==1.0.9
 httptools==0.6.4
-httpx==1.0.0b0
+httpx==0.28.1
 idna==3.10
 inflection==0.5.1
 itsdangerous==2.2.0


### PR DESCRIPTION
Updated version for **h11**, **httpcore** and **httpx**. Required to get this running on macOS (in Docker). The downgrade of **httpx** is interesting...